### PR TITLE
Optimize SliceRand

### DIFF
--- a/util/slice.go
+++ b/util/slice.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"math/rand"
-	"time"
 )
 
 // SliceUniq 切片去重
@@ -36,8 +35,7 @@ func SliceRand[T any](a []T, n int) []T {
 
 	copy(ret, a)
 
-	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
-	rnd.Shuffle(count, func(i, j int) {
+	rand.Shuffle(count, func(i, j int) {
 		ret[i], ret[j] = ret[j], ret[i]
 	})
 


### PR DESCRIPTION
Since go1.20 math/rand package now automatically seeds the global random number generator, there's no need to set Source handly. `rand.Shuffle` is fast enough and goroutine-safe.

Here's the benchmark highlights:

![image](https://github.com/shenghui0779/yiigo/assets/21255940/58e64d00-5e72-45b2-877a-b7fb7333e6aa)

You can find the full benchmark code [here](https://pastebin.com/9gwjSHqC)

For backwards compatibility: This change needs go1.20+, since go.mod's version directive is 1.20, and 1.19 has entered the EOL for more than 6 months, there's no backwards compatibility problems.
