### PR TITLE
fix time zone relevant tests

### DIFF
--- a/form_test.go
+++ b/form_test.go
@@ -151,6 +151,11 @@ func TestMappingTime(t *testing.T) {
 	}
 
 	var err error
+	// restore the local timezone
+	oldTZ := time.Local
+	defer func() {
+		time.Local = oldTZ
+	}()
 	time.Local, err = time.LoadLocation("Europe/Berlin")
 	assert.NoError(t, err)
 

--- a/time_test.go
+++ b/time_test.go
@@ -8,15 +8,21 @@ import (
 )
 
 func TestDate(t *testing.T) {
-	assert.Equal(t, "2016-03-19 15:03:19", TimeToStr(time.DateTime, 1458370999, time.Local))
+	tz, err := time.LoadLocation("Asia/Shanghai")
+	assert.NoError(t, err)
+	assert.Equal(t, "2016-03-19 15:03:19", TimeToStr(time.DateTime, 1458370999, tz))
 }
 
 func TestStrToTime(t *testing.T) {
-	assert.Equal(t, int64(1562910319), StrToTime(time.DateTime, "2019-07-12 13:45:19", time.Local).Unix())
+	tz, err := time.LoadLocation("Asia/Shanghai")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1562910319), StrToTime(time.DateTime, "2019-07-12 13:45:19", tz).Unix())
 }
 
 func TestWeekAround(t *testing.T) {
-	now := time.Unix(1562909685, 0).In(time.Local)
+	tz, err := time.LoadLocation("Asia/Shanghai")
+	assert.NoError(t, err)
+	now := time.Unix(1562909685, 0).In(tz)
 	monday, sunday := WeekAround(time.DateOnly, now)
 	assert.Equal(t, "2019-07-08", monday)
 	assert.Equal(t, "2019-07-14", sunday)


### PR DESCRIPTION
- Restore the "time.Local" if we change it in some test cases.
- Use "Asia/Shanghai" instead of "time.Local" since the hard-coded test target is in the CST.  If we use the "local time" the test will fail on my machine that in a deferent time zone.